### PR TITLE
Callbacks and result handling implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ ThreadPoolLib is a minimalist C++ thread pool library, designed with simplicity 
 
 * **Performance**: The library utilizes C++ `std::thread` to create and manage threads. It optimizes the number of threads created based on the number of cores available, ensuring optimal utilization of hardware resources.
 
+### Callbacks and Result Handling
+
+In addition to simply adding and running tasks concurrently, ThreadPoolLib also supports advanced use cases through task callbacks and result handling. Here's what you can do:
+
+- **Task Callbacks**: Add a callback function that will be invoked once a task has completed its execution. This can be useful for handling results, logging, or chaining tasks.
+
+- **Result Handling**: When a task finishes execution, it might return a result. With ThreadPoolLib, you can easily handle these results within the callback function, allowing you to use or store the outcome of the task.
+
+
 ## Future Enhancements
 
 This library is under active development and future enhancements include:
@@ -30,34 +39,88 @@ make
 
 ## Usage
 
-Include `ThreadPool.h` and create a `ThreadPool` object by specifying the number of threads you want to use. Then you can add tasks using the `AddTask` function.
+Include `include/ThreadPool.h` and create a `ThreadPool` object by specifying the number of threads you want to use. Then you can add tasks using the `AddTask()` or `AddTaskWithCallback()`functions.
 
-* **With Lambda**:
+
+## Usage
+
+The updated usage of ThreadPoolLib with the new features would be as follows:
+
+### Adding Tasks
+
+Include `ThreadPool.h` and create a `ThreadPool` object by specifying the number of threads you want to use. Then you can add tasks using the `AddTask` function.
 
 ```cpp
 ThreadPool tpl(std::thread::hardware_concurrency());
-
-tpl.AddTask([]() { std::cout << "\n My Task, thread id: "<< std::this_thread::get_id() <<" \n"; });
 ```
-* ****
+- **With Lambdas**:
 
-Aside from using lambda functions, `AddTask` also supports ordinary functions and functors. This can be handy when you have predefined tasks.
+```cpp
+tpl.AddTask([]() { std::cout << "\n My Task, thread id: " << std::this_thread::get_id() << " \n"; });
+```
 
-First, define your function:
+- **With Regular Functions**:
 
 ```cpp
 void foo() {
-    std::cout << "\n My Task, thread id: "<< std::this_thread::get_id() <<" \n";
+    std::cout << "\n My Task, thread id: " << std::this_thread::get_id() << " \n";
 }
-```
-
-Then pass the pointer to the function to AddTask:
-
-```cpp
-ThreadPool tpl(std::thread::hardware_concurrency());
 
 tpl.AddTask(foo);
 ```
+
+- **With Parameters**:
+
+```cpp
+void fooParam(int a, int b) {
+    std::cout << "\n My Task with parameters, thread id: " << std::this_thread::get_id() << " \n";
+}
+
+tpl.AddTask(fooParam, 4, 7);
+```
+
+### Adding Tasks with Callbacks
+
+- **With regular functions and callback**:
+
+```cpp
+void fooCallback() {
+    std::cout << "\n My Callback, thread id: " << std::this_thread::get_id() << " \n";
+}
+
+tpl.AddTaskWithCallback(foo, fooCallback);
+```
+
+- **With Result Handling**:
+
+```cpp
+int fooResult() {
+    int result = // some operation
+    return result;
+}
+
+void fooResultCallback(int result) {
+    std::cout << "\n Received result: "<< result << " from task, thread id: " << std::this_thread::get_id() <<" \n";
+}
+
+tpl.AddTaskWithCallback(fooResult, fooResultCallback);
+```
+
+- **With Result Handling and Parameters**:
+
+```cpp
+int fooResultAndParam(int x) {
+    int result = // some operation involving x
+return result;
+}
+
+void fooResultCallback(int result) {
+    std::cout << "\n Received result: "<< result <<" from task, thread id: " << std::this_thread::get_id() << " \n";
+}
+
+tpl.AddTaskWithCallback(fooResultAndParam, fooResultCallback, 9);
+```
+
 
 * Note: The testing mode is enabled in the `CMakeLists.txt` file. To use the library without the testing mode, simply comment out the line: 
 ```bash

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -21,12 +21,36 @@
 #include <iostream>
 #include "ThreadPool.h"
 
-#ifdef DEBUG
-#define MAX_TASK_TESTS 500
-#endif
-
 void foo(){
-    std::cout << "\n My Task, thread id: "<< std::this_thread::get_id() <<" \n";
+    std::cout << "\n [Task]: foo(), thread id: " << std::this_thread::get_id() << "\n";
+    std::this_thread::sleep_for(std::chrono::seconds(2)); // Simulate a 2 seconds process/delay.
+}
+
+void fooParam(int a, int b){
+    std::cout << "\n [Task]: fooParam(), and my parameters are: " << a << " and "<< b <<" - thread id: " << std::this_thread::get_id() << "\n";
+    std::this_thread::sleep_for(std::chrono::seconds(2)); // Simulate a 2 seconds process/delay.
+}
+
+void fooCallback(){
+    std::cout << "\n [Callback]: fooCallback(), thread id: " << std::this_thread::get_id() << "\n";
+}
+
+int fooResult(){
+    int result = 9;
+    std::cout << "\n [Task]: fooResult(), My result will be: " << result << " - thread id: " << std::this_thread::get_id() << "\n";
+    std::this_thread::sleep_for(std::chrono::seconds(2)); // Simulate a 2 seconds process/delay.
+    return result;
+}
+
+int fooResultAndParam(int a){
+    int result = a * 2;
+    std::cout << "\n [Task]: fooResultAndParam(), My result will be: "<< a << "*2 = "  << result << " - thread id: " << std::this_thread::get_id() << "\n";
+    std::this_thread::sleep_for(std::chrono::seconds(2)); // Simulate a 2 seconds process/delay.
+    return result;
+}
+
+void fooResultCallback(int a){
+    std::cout << "\n [Callback]: fooResultCallback(), Data result: " << a << "  - thread id: " << std::this_thread::get_id() << "\n";
 }
 
 int main() {
@@ -34,9 +58,32 @@ int main() {
 #ifdef DEBUG
     ThreadPool tpl(std::thread::hardware_concurrency());
 
-    for(int i = 0; i <= MAX_TASK_TESTS; i++){
-        tpl.AddTask([]() { std::cout << "\n My Task, thread id: "<< std::this_thread::get_id() <<" \n"; });
-    }
+    /**
+     * Tasks
+     */
+
+    // With a lambda.
+    tpl.AddTask([]() { std::cout << "\n Adding my task with a lambda, thread id: " << std::this_thread::get_id() << "\n"; });
+
+    // Normal task "Fire-and-forget"
+    tpl.AddTask(foo);
+
+    // Normal task,  with parameters.
+    tpl.AddTask(fooParam, 4, 7);
+
+    /**
+     * Tasks + Callbacks
+     */
+
+    // Adding a task with a Callback which will be called after the task is complete.
+    tpl.AddTaskWithCallback(foo, fooCallback);
+
+    // Callback which will receive the task's result.
+    tpl.AddTaskWithCallback(fooResult, fooResultCallback);
+
+    // The task will have some args (9 in the example), the result of it will be sent to the callback
+    tpl.AddTaskWithCallback(fooResultAndParam, fooResultCallback, 9);
+
 #endif
 
     return 0;


### PR DESCRIPTION
### Callbacks and Result Handling

In addition to simply adding and running tasks concurrently, ThreadPoolLib also supports advanced use cases through task callbacks and result handling. Here's what you can do:

- **Task Callbacks**: Add a callback function that will be invoked once a task has completed its execution. This can be useful for handling results, logging, or chaining tasks.

- **Result Handling**: When a task finishes execution, it might return a result. With ThreadPoolLib, you can easily handle these results within the callback function, allowing you to use or store the outcome of the task.
