### PR TITLE
Use std::unique_lock and std::condition_variable  for performance improvements and mutex flexibility.

### DIFF
--- a/examples/examples.cpp
+++ b/examples/examples.cpp
@@ -36,9 +36,10 @@ int main() {
 
     // With lambdas
     tpl.AddTask([]() { std::cout << "\n Adding my task with a lambda, thread id: " << std::this_thread::get_id() << "\n"; });
+    tpl.AddTask([]() { std::cout << "\n Adding my task with a lambda, thread id: " << std::this_thread::get_id() << "\n"; });
 
     // If we need the tasks to be methods, we can use a lambda to capture them.
-    tpl.AddTask([&fooObj1, fooObj2]() {
+    tpl.AddTask([&fooObj1, &fooObj2]() {
         printf("Lambda Task %i", fooObj1.MyTask(9));
         fooObj2->MyTask(1399);
         fooObj1.MyCallback(fooObj1.MyTask(4 * 1));

--- a/include/Macros.h
+++ b/include/Macros.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the ThreadPoolLib project.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @author - Geru-Scotland (https://github.com/geru-scotland)
+ */
+
+
+#ifndef THREADPOOLLIB_MACROS_H
+#define THREADPOOLLIB_MACROS_H
+
+#define TRACE_LOG(fmt, ...) do { \
+    std::fprintf(stdout, "%s:%d:%s(): " fmt "\n", __FILE__, \
+        __LINE__, __func__, ##__VA_ARGS__); \
+    } while (0)
+
+#endif //THREADPOOLLIB_MACROS_H


### PR DESCRIPTION
Thanks to the ability to put each thread into a wait state when there are no tasks to consume, we avoid the constant mutex lock/unlock operations and the checks performed during each iteration when using **std::lock_guard**.

A thread will be notified when a task is added to the queue. If the conditions are met, it will acquire the mutex lock and wake from its wait state, allowing the task to be consumed or executed